### PR TITLE
docs: readme release flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,9 +183,7 @@ graph LR
 
 ## Release Flow
 
-### リポジトリ公開後
-
-Contentful でコンテンツを編集した後のデプロイを GUI で完結させるため、GitHub Actions を使用します。
+Contentful でコンテンツを編集した後のデプロイを GUI で完結させるかつ、誤って公開することを避けるため、GitHub Actions を使用します。
 
 Actions の [Continuous Delivery ワークフロー](https://github.com/meguroes/next.meguro.es/actions/workflows/continuous_delivery.yaml) から、 `Run Workflow` ボタンを押下します。
 
@@ -194,7 +192,3 @@ Actions の [Continuous Delivery ワークフロー](https://github.com/meguroes
 ブランチを `main` にセットし、ポップアップ内の `Run Workflow` を押下すると Cloudflare Pages にデプロイされます。
 
 ![スクリーンショット 2023-12-28 午後7 41 13](https://github.com/meguroes/next.meguro.es/assets/38882716/c695f8a9-5536-4eb0-8ca5-3909623ce6e6)
-
-### リポジトリ公開前（公開後廃止予定）
-
-`main` ブランチに push すると Cloudflare Pages にデプロイされます。


### PR DESCRIPTION
リポジトリ公開により、GitHub Actionsの上限がなくなったので Cloudflare 側の CD を削除しました。